### PR TITLE
Corrected path to JSON file in R instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Instructions:
 
 4. Import data to a spatial dataframe. City data is typically created using the transverse Mercator projection.
     ```r
-    ogrInfo("data\\pedway.json", layer="OGRGeoJSON")
-    pedway.shapefile <- readOGR(dsn="data\\pedway.json", layer="OGRGeoJSON", p4s="+proj=tmerc +ellps=WGS84")
+    ogrInfo("data/Pedway_Routes.json", layer="OGRGeoJSON")
+    pedway.shapefile <- readOGR(dsn="data/Pedway_Routes.json", layer="OGRGeoJSON", p4s="+proj=tmerc +ellps=WGS84")
     ```
 
 5. Ensure the map works:


### PR DESCRIPTION
I followed the instructions with R version 2.15.2 on OS X 10.8.2, and they worked perfectly except that I needed to correct the path to the pedway JSON file.
